### PR TITLE
fix: selection of files will stay in the commit window, if user chang…

### DIFF
--- a/gui/src/main/java/de/adito/git/gui/dialogs/CommitDialog.java
+++ b/gui/src/main/java/de/adito/git/gui/dialogs/CommitDialog.java
@@ -230,7 +230,10 @@ class CommitDialog extends AditoBaseDialog<CommitDialogResult> implements IDisca
       {
         // adding the selected File to the selected Files
         FileChangeTypeNode fileChangeTypeNode = (FileChangeTypeNode) selectionPath.getLastPathComponent();
-        selectedFiles.add(fileChangeTypeNode.getInfo().getNodeFile());
+        for (IFileChangeType fileChangeType : fileChangeTypeNode.getInfo().getMembers())
+        {
+          selectedFiles.add(fileChangeType.getFile());
+        }
       }
     }
   }

--- a/gui/src/main/java/de/adito/git/gui/dialogs/CommitDialog.java
+++ b/gui/src/main/java/de/adito/git/gui/dialogs/CommitDialog.java
@@ -1,5 +1,6 @@
 package de.adito.git.gui.dialogs;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import com.jidesoft.swing.*;
@@ -25,6 +26,7 @@ import de.adito.util.reactive.AbstractListenerObservable;
 import de.adito.util.reactive.cache.*;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
+import lombok.*;
 import org.jetbrains.annotations.*;
 
 import javax.swing.*;
@@ -63,6 +65,7 @@ class CommitDialog extends AditoBaseDialog<CommitDialogResult> implements IDisca
   private final IIconLoader iconLoader;
   private final IPrefStore prefStore;
   private final Observable<Optional<IRepository>> repository;
+  @Getter(AccessLevel.PROTECTED)
   private final SearchableCheckboxTree checkBoxTree;
   private final ObservableCache observableCache = new ObservableCache();
   private final CompositeDisposable disposables = new CompositeDisposable();
@@ -74,10 +77,10 @@ class CommitDialog extends AditoBaseDialog<CommitDialogResult> implements IDisca
 
   @Inject
   public CommitDialog(IFileSystemUtil pFileSystemUtil, IQuickSearchProvider pQuickSearchProvider, IActionProvider pActionProvider, LookupProvider pLookupProvider,
-                      IIconLoader pIconLoader, IPrefStore pPrefStore, @Assisted IDialogDisplayer.IDescriptor pIsValidDescriptor,
-                      @Assisted Observable<Optional<IRepository>> pRepository, @Assisted Observable<Optional<List<IFileChangeType>>> pFilesToCommit,
-                      @Assisted String pMessageTemplate, @Assisted DelayedSupplier<List<IBeforeCommitAction>> pSelectedActionsSupplier,
-                      @Assisted DelayedSupplier<List<File>> pDelayedSupplier, IEditorKitProvider pEditorKitProvider)
+                      IIconLoader pIconLoader, IPrefStore pPrefStore, @Assisted @NotNull IDialogDisplayer.IDescriptor pIsValidDescriptor,
+                      @Assisted @NotNull Observable<Optional<IRepository>> pRepository, @Assisted @NotNull Observable<Optional<List<IFileChangeType>>> pFilesToCommit,
+                      @Assisted String pMessageTemplate, @Assisted @NotNull DelayedSupplier<List<IBeforeCommitAction>> pSelectedActionsSupplier,
+                      @Assisted @NotNull DelayedSupplier<List<File>> pDelayedSupplier, IEditorKitProvider pEditorKitProvider)
   {
     actionProvider = pActionProvider;
     lookupProvider = pLookupProvider;
@@ -188,20 +191,48 @@ class CommitDialog extends AditoBaseDialog<CommitDialogResult> implements IDisca
             .collect(Collectors.toList()))
         .orElse(List.of());
     JScrollPane scrollPane = new JScrollPane(checkBoxTree);
+
+    List<File> selectedFiles = new ArrayList<>();
+    Runnable doBeforeJob = () -> _detectSelectedFiles(selectedFiles);
+
     Runnable[] doAfterJobs = new Runnable[3];
     doAfterJobs[0] = () -> TreeUtil.expandTreeInterruptible(checkBoxTree);
-    doAfterJobs[1] = () -> _markPreselectedAndExpand(statusTreeModel, preSelectedFiles);
+    doAfterJobs[1] = () -> _markPreselectedAndExpand(statusTreeModel, !selectedFiles.isEmpty() ? selectedFiles : preSelectedFiles);
     doAfterJobs[2] = () -> {
       tableSearchView.remove(loadingLabel);
       tableSearchView.add(scrollPane, BorderLayout.CENTER);
       revalidate();
       repaint();
     };
-    treeUpdater = new ObservableTreeUpdater<>(pFilesToCommitObs, statusTreeModel, pFileSystemUtil, doAfterJobs);
+
+    treeUpdater = new ObservableTreeUpdater<>(pFilesToCommitObs, statusTreeModel, pFileSystemUtil, doAfterJobs, doBeforeJob);
     loadingLabel.setHorizontalAlignment(SwingConstants.CENTER);
     tableSearchView.add(loadingLabel, BorderLayout.CENTER);
     pQuickSearchProvider.attach(tableSearchView, BorderLayout.SOUTH, new QuickSearchTreeCallbackImpl(checkBoxTree));
     _attachPopupMenu(checkBoxTree);
+  }
+
+  /**
+   * Detects the selected files from the {@link #checkBoxTree} and adds them to the given list. This method is run before the tree is changed,
+   * so the selection will be stored and can later be applied to the new tree.
+   *
+   * @param selectedFiles the list with the selected file. Because call-by-reference the list has the changed elements which don't needed to be returned.
+   */
+  @VisibleForTesting
+  void _detectSelectedFiles(@NotNull List<File> selectedFiles)
+  {
+    // clears the old selection
+    selectedFiles.clear();
+    // goes over all selected TreePaths
+    for (TreePath selectionPath : checkBoxTree.getCheckBoxTreeSelectionModel().getSelectionPaths())
+    {
+      if (selectionPath.getLastPathComponent() instanceof FileChangeTypeNode)
+      {
+        // adding the selected File to the selected Files
+        FileChangeTypeNode fileChangeTypeNode = (FileChangeTypeNode) selectionPath.getLastPathComponent();
+        selectedFiles.add(fileChangeTypeNode.getInfo().getNodeFile());
+      }
+    }
   }
 
   /**

--- a/gui/src/test/java/de/adito/git/gui/dialogs/CommitDialogTest.java
+++ b/gui/src/test/java/de/adito/git/gui/dialogs/CommitDialogTest.java
@@ -2,9 +2,10 @@ package de.adito.git.gui.dialogs;
 
 import de.adito.aditoweb.nbm.nbide.nbaditointerface.git.IBeforeCommitAction;
 import de.adito.git.api.IRepository;
-import de.adito.git.api.data.diff.IFileChangeType;
+import de.adito.git.api.data.diff.*;
 import de.adito.git.gui.DelayedSupplier;
 import de.adito.git.gui.tree.nodes.*;
+import de.adito.git.impl.data.FileChangeTypeImpl;
 import io.reactivex.rxjava3.core.Observable;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
@@ -46,11 +47,13 @@ class CommitDialogTest
     List<File> selectedFiles = new ArrayList<>();
     selectedFiles.add(new File("c:/projects/basic/readme.md"));
 
-    
+
     commitDialog._detectSelectedFiles(selectedFiles);
+    Collections.sort(selectedFiles);
 
-
-    assertEquals(Arrays.asList(packageJson, entityValueChange), selectedFiles);
+    List<File> expected = Arrays.asList(packageJson, entityValueChange);
+    Collections.sort(expected);
+    assertEquals(expected, selectedFiles);
   }
 
   /**
@@ -62,6 +65,7 @@ class CommitDialogTest
   @NotNull
   private static TreePath createTreePath(@NotNull File nodeFile)
   {
-    return new TreePath(new FileChangeTypeNode(new FileChangeTypeNodeInfo("not relevant", nodeFile, List.of())));
+    IFileChangeType iFileChangeType = new FileChangeTypeImpl(nodeFile, nodeFile, EChangeType.CHANGED);
+    return new TreePath(new FileChangeTypeNode(new FileChangeTypeNodeInfo("not relevant", new File("C:/should/not/be/used"), List.of(iFileChangeType))));
   }
 }

--- a/gui/src/test/java/de/adito/git/gui/dialogs/CommitDialogTest.java
+++ b/gui/src/test/java/de/adito/git/gui/dialogs/CommitDialogTest.java
@@ -1,0 +1,67 @@
+package de.adito.git.gui.dialogs;
+
+import de.adito.aditoweb.nbm.nbide.nbaditointerface.git.IBeforeCommitAction;
+import de.adito.git.api.IRepository;
+import de.adito.git.api.data.diff.IFileChangeType;
+import de.adito.git.gui.DelayedSupplier;
+import de.adito.git.gui.tree.nodes.*;
+import io.reactivex.rxjava3.core.Observable;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.swing.tree.TreePath;
+import java.io.File;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test class for {@link CommitDialog}.
+ *
+ * @author r.hartinger, 17.11.2022
+ */
+class CommitDialogTest
+{
+
+  /**
+   * Tests if the selected Files are correctly detected and old results are thrown away.
+   */
+  @Test
+  void testDetectSelectedFiles()
+  {
+    IDialogDisplayer.IDescriptor pIsValidDescriptor = Mockito.mock(IDialogDisplayer.IDescriptor.class);
+    Observable<Optional<IRepository>> pRepository = Observable.just(Optional.empty());
+    Observable<Optional<List<IFileChangeType>>> pFilesToCommit = Observable.just(Optional.empty());
+    DelayedSupplier<List<File>> pDelayedSupplier = new DelayedSupplier<>();
+    DelayedSupplier<List<IBeforeCommitAction>> pSelectedActionsSupplier = new DelayedSupplier<>();
+
+    CommitDialog commitDialog = new CommitDialog(null, null, null, null, null, null, pIsValidDescriptor, pRepository, pFilesToCommit, null, pSelectedActionsSupplier, pDelayedSupplier, null);
+
+    File packageJson = new File("c:/projects/basic/package.json");
+    File entityValueChange = new File("c:/projects/basic/entity/My_entity/entityfields/myfield/onValueChange.js");
+
+    commitDialog.getCheckBoxTree().getCheckBoxTreeSelectionModel().addSelectionPaths(new TreePath[]{createTreePath(packageJson), createTreePath(entityValueChange)});
+
+    List<File> selectedFiles = new ArrayList<>();
+    selectedFiles.add(new File("c:/projects/basic/readme.md"));
+
+    
+    commitDialog._detectSelectedFiles(selectedFiles);
+
+
+    assertEquals(Arrays.asList(packageJson, entityValueChange), selectedFiles);
+  }
+
+  /**
+   * Creates a simple TreePath. Only the file is relevant in this case.
+   *
+   * @param nodeFile the file of the FileChangeTypeNodeInfo
+   * @return the created tree path
+   */
+  @NotNull
+  private static TreePath createTreePath(@NotNull File nodeFile)
+  {
+    return new TreePath(new FileChangeTypeNode(new FileChangeTypeNodeInfo("not relevant", nodeFile, List.of())));
+  }
+}


### PR DESCRIPTION
…es a file from outside, reverts a file or changes the display of the commit checkbox tree (#2013191)