### PR TITLE
adjusted test to run on windows

### DIFF
--- a/nbm/src/test/java/de/adito/git/nbm/FileSystemObserverImplTest.java
+++ b/nbm/src/test/java/de/adito/git/nbm/FileSystemObserverImplTest.java
@@ -36,7 +36,7 @@ class FileSystemObserverImplTest
   @BeforeAll
   static void beforeAll() throws IOException
   {
-    tempDirectory = Files.createTempDirectory("fileSystemObserverImplTest");
+    tempDirectory = Files.createTempDirectory("fileSystemObserverImplTest").toRealPath();
     FileObject projectDir = FileUtil.toFileObject(tempDirectory.toFile());
     repositoryDescription = new ProjectRepositoryDescription(projectDir);
   }


### PR DESCRIPTION
File path was different, which caused the problem
in the method initFileSystemObserver:  `C:\Users\R5F21~1.HAR\AppData\Local\Temp\fileSystemObserverImplTest1704189076951857893`
in the constructor of FileSystemObserverImpl
`C:\Users\r.hartinger\AppData\Local\Temp\fileSystemObserverImplTest1704189076951857893`